### PR TITLE
Add TutorialSearch to Video Tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ A community-driven collection of Redwood related plugins, config, themes, build 
 * [Part 2](https://www.youtube.com/watch?v=SP5vbsWf5Yg)
 * [Part 3](https://www.youtube.com/watch?v=eT7iIy0F8Tk)
 * [Part 4](https://www.youtube.com/watch?v=UpD3HyuZkvY)
+* [TutorialSearch](https://tutorialsearch.io/) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
 
 ## Deployment
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ A community-driven collection of Redwood related plugins, config, themes, build 
 * [Part 2](https://www.youtube.com/watch?v=SP5vbsWf5Yg)
 * [Part 3](https://www.youtube.com/watch?v=eT7iIy0F8Tk)
 * [Part 4](https://www.youtube.com/watch?v=UpD3HyuZkvY)
-* [TutorialSearch](https://tutorialsearch.io/) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
+* [TutorialSearch](https://tutorialsearch.io/browse/web-development/graphql-apis) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
 
 ## Deployment
 


### PR DESCRIPTION
Hi! This PR adds **TutorialSearch** to the *Video Tutorial* section.

### What is TutorialSearch?
[TutorialSearch](https://tutorialsearch.io/browse/web-development/graphql-apis) is a free, cross-platform search engine that indexes 50,000+ tutorials and courses from major learning platforms (Udemy, Skillshare, Pluralsight, and more) across 45+ categories — including programming, web development, AI/ML, cybersecurity, design, and more. No signup required.

It helps learners compare tutorials side-by-side by rating, price, and reviews before committing to a course, which I think makes it a useful addition to this list.

### Entry added
```
- [TutorialSearch](https://tutorialsearch.io/browse/web-development/graphql-apis) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
```

Inserted in alphabetical order within the section. Happy to adjust formatting, description length, or placement if you'd like — just let me know!

Thanks for maintaining this list.